### PR TITLE
Boost init priority before main loop

### DIFF
--- a/init/init.cpp
+++ b/init/init.cpp
@@ -829,6 +829,8 @@ int SecondStageMain(int argc, char** argv) {
     // Run all property triggers based on current state of the properties.
     am.QueueBuiltinAction(queue_property_triggers_action, "queue_property_triggers");
 
+    // Restore prio before main loop
+    setpriority(PRIO_PROCESS, 0, 0);
     while (true) {
         // By default, sleep until something happens.
         auto epoll_timeout = std::optional<std::chrono::milliseconds>{};

--- a/init/main.cpp
+++ b/init/main.cpp
@@ -52,7 +52,8 @@ int main(int argc, char** argv) {
 #if __has_feature(address_sanitizer)
     __asan_set_error_report_callback(AsanReportCallback);
 #endif
-
+    // Boost prio which will be restored later
+    setpriority(PRIO_PROCESS, 0, -20);
     if (!strcmp(basename(argv[0]), "ueventd")) {
         return ueventd_main(argc, argv);
     }

--- a/init/subcontext.cpp
+++ b/init/subcontext.cpp
@@ -18,6 +18,8 @@
 
 #include <fcntl.h>
 #include <poll.h>
+#include <sys/time.h>
+#include <sys/resource.h>
 #include <unistd.h>
 
 #include <android-base/file.h>
@@ -182,6 +184,8 @@ int SubcontextMain(int argc, char** argv, const KeywordFunctionMap* function_map
     };
 
     auto subcontext_process = SubcontextProcess(function_map, context, init_fd);
+    // Restore prio before main loop
+    setpriority(PRIO_PROCESS, 0, 0);
     subcontext_process.MainLoop();
     return 0;
 }

--- a/init/ueventd.cpp
+++ b/init/ueventd.cpp
@@ -319,6 +319,8 @@ int ueventd_main(int argc, char** argv) {
     while (waitpid(-1, nullptr, WNOHANG) > 0) {
     }
 
+    // Restore prio before main loop
+    setpriority(PRIO_PROCESS, 0, 0);
     uevent_listener.Poll([&uevent_handlers](const Uevent& uevent) {
         for (auto& uevent_handler : uevent_handlers) {
             uevent_handler->HandleUevent(uevent);


### PR DESCRIPTION
Now we have more things e.g. loading kernel modules, initialize
selinux. And before all these, system cannot make further progress. It
should be beneficial to boost this critical peroid in init.

Benchmark on a Pixel device shows this saves 100+ms on early boot

ToT release + This CL (P15538587)
D/BaseBootTest: init_stage_second_START_TIME_avg : 1563.4
D/BaseBootTest: ueventd_Coldboot_avg : 219.0
D/BaseBootTest: action_init_/system/etc/init/hw/init.rc:114_START_TIME_avg : 2103.7

ToT release (6654154)
D/BaseBootTest: init_stage_second_START_TIME_avg : 1639.0
D/BaseBootTest: ueventd_Coldboot_avg : 238.2
D/BaseBootTest: action_init_/system/etc/init/hw/init.rc:114_START_TIME_avg : 2226.0

Bug: 143857500
Bug: 147997403
Bug: 160271169
Bug: 160696502
Test: Boottime
Signed-off-by: Wei Wang <wvw@google.com>
Change-Id: I21c9e051f4ae3e953d991c031f151b2779702548